### PR TITLE
#19 into release/fetches/1.13.3 💎 ensure fetches ESM/CJS type resolution

### DIFF
--- a/packages/fetches/package.json
+++ b/packages/fetches/package.json
@@ -29,14 +29,14 @@
         "default": "./dist/esm/index.mjs"
       },
       "require": {
-        "types": "./dist/types/index.d.cts",
+        "types": "./dist/types/index.d.ts",
         "default": "./dist/cjs/index.cjs"
       }
     }
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
-  "types": "dist/types/index.d.cts",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist/**/*"
   ],

--- a/packages/fetches/vite.config.js
+++ b/packages/fetches/vite.config.js
@@ -1,33 +1,20 @@
-import fs from 'node:fs/promises';
+import { copyFileSync } from 'node:fs';
 import path from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
 import pkg from './package.json';
 
-const typesDir = path.resolve(__dirname, 'dist/types');
-const typesEntry = path.join(typesDir, 'index.d.ts');
-
-const dualTypesPlugin = () => ({
-  name: 'dual-types',
-  async closeBundle() {
-    const typesContent = await fs.readFile(typesEntry, 'utf8');
-    await Promise.all([
-      fs.writeFile(path.join(typesDir, 'index.d.mts'), typesContent),
-      fs.writeFile(path.join(typesDir, 'index.d.cts'), typesContent)
-    ]);
-    await fs.unlink(typesEntry);
-  }
-});
-
 export default defineConfig({
   plugins: [
     dts({
+      afterBuild: () => {
+        copyFileSync('dist/types/index.d.ts', 'dist/types/index.d.mts');
+      },
       entryRoot: 'src',
       outDir: 'dist/types',
       tsconfigPath: './tsconfig.json'
-    }),
-    dualTypesPlugin()
+    })
   ],
   build: {
     lib: {


### PR DESCRIPTION
## Summary
- generate dual module-typed declarations (.d.mts/.d.cts) during the fetches build
- align package exports/main/module/types with actual ESM/CJS outputs
- remove the intermediate index.d.ts after copying

## Explanation
This fix is necessary for fetches package because it has default export. There a lot of troubles with interop between CJS and ESM when it comes to default export so we need to point to right files explicitly.